### PR TITLE
Implemented fukkit for doing things live

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Whynot also defines `Kernel#meh`, for when you really don't give a shit.
 Sometimes it'll be `true`, sometimes `false`. But you don't care about that,
 do you?
 
+#### Production-Only Code
+
+Whynot also defines 'Kernel#fukkit' for when you just want [to do it live](https://www.youtube.com/watch?v=bgCJPdsBWnA).
+The code will only be executed if `RUBY_ENV` is equal to `production`; otherwise, the default value will be returned.
+
+```ruby
+fukkit do  # Default handling; returns nil outside of production
+  # This block is executed in production, and its return value is returned
+end
+```
+
+```ruby
+fukkit(42) do # Default handling; returns 42 outside of production
+  # This block is executed in production, and its return value is returned
+end
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/[my-github-username]/whynot/fork )

--- a/lib/whynot.rb
+++ b/lib/whynot.rb
@@ -27,4 +27,17 @@ module Kernel
   def meh
     rand(2) == 1 ? true : false
   end
+
+  ##
+  # For documentation, see https://www.youtube.com/watch?v=bgCJPdsBWnA
+  ##
+  def fukkit(default=nil, &block)
+    return default if ENV['RUBY_ENV'] != "production"
+    begin
+      yield
+    rescue
+      default
+    end
+  end
+
 end

--- a/spec/whynot_spec.rb
+++ b/spec/whynot_spec.rb
@@ -5,4 +5,79 @@ describe 'meh' do
   it "should be true or false" do
     expect(meh.to_s).to match(/true|false/)
   end
+
+end
+
+describe 'fukkit' do
+
+  after do
+    ENV['RUBY_ENV'] = 'test'
+  end
+
+  context "should default outside of production" do
+
+    before do
+      ENV['RUBY_ENV'] = 'development'
+    end
+
+    context "even if the block would explode" do
+
+      it "without a default value" do
+        expect(fukkit { 1/0 }).to be_nil
+      end
+
+      it "with a default value" do
+        expect(fukkit(42) { 1/0 }).to eql(42)
+      end
+
+    end
+
+    context "when the block would return a value" do
+
+      it "without a default value" do
+        expect(fukkit { 1 }).to be_nil
+      end
+
+      it "with a default value" do
+        expect(fukkit(42) { 1 }).to eql(42)
+      end
+
+    end
+
+  end
+
+  context "should use the real value" do
+
+    before do
+      ENV['RUBY_ENV'] = 'production'
+    end
+
+    context "unless the block would explode" do
+
+      it "without a default value" do
+        expect(fukkit { 1/0 }).to be_nil
+      end
+
+      it "with a default value" do
+        expect(fukkit(42) { 1/0 }).to eql(42)
+      end
+
+    end
+
+    context "when the block successfully returns a value" do
+
+      it "without a default value" do
+        expect(fukkit { 1 }).not_to be_nil
+        expect(fukkit { 1 }).to eql(1)
+      end
+
+      it "with a default value" do
+        expect(fukkit(42) { 1 }).not_to eql(42)
+        expect(fukkit(42) { 1 }).to eql(1)
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Defines 'Kernel#fukkit' for when you just want [to do it live](https://www.youtube.com/watch?v=bgCJPdsBWnA) -- code is only executed in `RUBY_ENV` equals `"production"`.